### PR TITLE
Design/#16/supporter landing page publishing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "kurierfree-client",
       "version": "0.0.0",
       "dependencies": {
+        "@heroicons/react": "^2.2.0",
         "@tanstack/react-table": "^8.21.2",
         "@types/react-router-dom": "^5.3.3",
         "react": "^19.0.0",
@@ -825,6 +826,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@heroicons/react": "^2.2.0",
     "@tanstack/react-table": "^8.21.2",
     "@types/react-router-dom": "^5.3.3",
     "react": "^19.0.0",

--- a/src/components/common/BarrierFreeMapCard.tsx
+++ b/src/components/common/BarrierFreeMapCard.tsx
@@ -1,0 +1,18 @@
+import { MapIcon, ArrowRightIcon } from '@heroicons/react/24/outline';
+
+const BarrierFreeMapCard = () => {
+  return (
+    <div className="w-[455px] h-[270px] bg-white rounded-[16px] border border-[#D9D9D9] relative flex flex-col justify-between p-5 shadow-sm">
+      {/* 상단 지도 아이콘 */}
+      <MapIcon className="w-10 h-10 text-[#444] absolute top-4 right-4" />
+      {/* 중앙 텍스트 */}
+      <div className="flex-1 flex items-center justify-end">
+        <span className="text-[#444] text-[28px] font-semibold text-right">건국대학교 배리어프리맵</span>
+      </div>
+      {/* 하단 화살표 */}
+      <ArrowRightIcon className="w-6 h-6 text-[#444] absolute left-4 bottom-4" />
+    </div>
+  );
+};
+
+export default BarrierFreeMapCard; 

--- a/src/components/common/CalendarCard.tsx
+++ b/src/components/common/CalendarCard.tsx
@@ -1,0 +1,21 @@
+const CalendarCard = () => {
+  return (
+    <div className="bg-white rounded-xl shadow p-6 h-full">
+        {/* 날짜 헤더 */}
+        <div className="grid grid-cols-6 text-center font-semibold text-sm mb-4">
+        <div>3/3</div>
+        <div>3/4</div>
+        <div>3/5</div>
+        <div>3/6</div>
+        <div>3/7</div>
+        <div></div>
+        </div>
+        {/* 시간표 (샘플) */}
+        <div className="grid grid-rows-9 grid-cols-6 gap-px text-sm text-center">
+        {[...Array(9 * 6)].map((_, i) => (
+            <div key={i} className="h-10 border bg-yellow-50">{i % 6 === 1 && i < 36 ? '수업 필기' : ''}</div>
+        ))}
+        </div>
+    </div>
+)}
+export default CalendarCard;

--- a/src/components/common/EmergencyContactCard.tsx
+++ b/src/components/common/EmergencyContactCard.tsx
@@ -1,0 +1,18 @@
+import { PhoneIcon, ArrowRightIcon } from '@heroicons/react/24/outline';
+
+const EmergencyContactCard = () => {
+  return (
+    <div className="w-[220px] h-[170px] bg-secondary-disabled rounded-[16px] border border-[#2196F3] relative flex flex-col justify-between p-5 shadow-sm">
+      {/* 상단 아이콘 */}
+      <PhoneIcon className="w-8 h-8 text-[#444] absolute top-4 right-4" />
+      {/* 중앙 텍스트 */}
+      <div className="flex-1 flex items-center justify-end">
+        <span className="text-[#444] text-[28px] font-semibold text-right">긴급 연락처</span>
+      </div>
+      {/* 하단 화살표 */}
+      <ArrowRightIcon className="w-6 h-6 text-[#444] absolute left-4 bottom-4" />
+    </div>
+  );
+};
+
+export default EmergencyContactCard; 

--- a/src/components/common/LearningHelperCard.tsx
+++ b/src/components/common/LearningHelperCard.tsx
@@ -1,0 +1,18 @@
+import { BookOpenIcon, ArrowRightIcon } from '@heroicons/react/24/outline';
+
+const LearningHelperCard = () => {
+  return (
+    <div className="w-[220px] h-[170px] bg-primary-disabled rounded-[16px] border border-[#4CAF4F]/70 relative flex flex-col justify-between p-5 shadow-sm">
+      {/* 상단 아이콘 */}
+      <BookOpenIcon className="w-8 h-8 text-[#444] absolute top-4 right-4" />
+      {/* 중앙 텍스트 */}
+      <div className="flex-1 flex items-center justify-end">
+        <span className="text-[#444] text-[28px] font-semibold text-right">학습 도우미</span>
+      </div>
+      {/* 하단 화살표 */}
+      <ArrowRightIcon className="w-6 h-6 text-[#444] absolute left-4 bottom-4" />
+    </div>
+  );
+};
+
+export default LearningHelperCard;

--- a/src/components/common/ProfileCard.tsx
+++ b/src/components/common/ProfileCard.tsx
@@ -17,7 +17,7 @@ const SupporterProfileCard: React.FC<SupporterProfileCardProps> = ({
 }) => {
   return (
     <div
-      className="bg-[#BFE0C3] rounded-xl p-6 shadow-sm border-2 border-[#66BA6A] w-[45.5%] min-w-[300px] max-w-full"
+      className="w-[672px] bg-[#BFE0C3] rounded-xl p-6 shadow-sm border border-[#66BA6A] min-w-[672px] max-w-[672px]"
     >
       <div className="flex items-center gap-2 mb-1">
         <span

--- a/src/components/common/ProfileCard.tsx
+++ b/src/components/common/ProfileCard.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { ArrowRightIcon } from '@heroicons/react/24/outline';
+interface SupporterProfileCardProps {
+  name: string;
+  role: string;
+  label: string; // ex: '담당 학우', '담당 서포터즈'
+  people: string[];
+  onLogout?: () => void;
+}
+
+const SupporterProfileCard: React.FC<SupporterProfileCardProps> = ({
+  name,
+  role,
+  label,
+  people,
+  onLogout,
+}) => {
+  return (
+    <div
+      className="bg-[#BFE0C3] rounded-xl p-6 shadow-sm border-2 border-[#66BA6A] w-[45.5%] min-w-[300px] max-w-full"
+    >
+      <div className="flex items-center gap-2 mb-1">
+        <span
+          className="font-semibold text-[25px] leading-[35px] tracking-normal text-gray-800 font-inter"
+        >
+          {name}
+        </span>
+        <span
+          className="font-bold text-[19px] leading-[35px] tracking-normal text-[#4CAF4F] font-inter"
+        >
+          @{role}
+        </span>
+      </div>
+      <div className="flex items-center justify-between">
+        <div
+          className="font-medium text-[21px] leading-[35px] tracking-normal text-[#333333] font-inter"
+        >
+          {label}: {people.join(', ')}
+        </div>
+        <button
+          className="bg-primary hover:bg-[#4CAF4F] text-white font-semibold px-6 py-2 rounded transition-all flex items-center ml-4"
+          onClick={onLogout}
+        >
+          로그아웃
+          <ArrowRightIcon className="w-4 h-4 ml-4" strokeWidth={2} />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default SupporterProfileCard;

--- a/src/components/common/ServiceInfoCard.tsx
+++ b/src/components/common/ServiceInfoCard.tsx
@@ -1,0 +1,19 @@
+import logo from '../../assets/images/logo.svg'
+import logoTitle from '../../assets/images/logo-title.svg'
+
+const ServiceInfoCard = () => {
+  return (
+    <div className="bg-white rounded-2xl border border-[#D9D9D9] px-8 py-6 flex items-center gap-6 shadow-sm w-[400px] min-w-[320px] max-w-full">
+      <img src={logo} alt="KUrier Free Logo" className="w-28 h-28" />
+      <div>
+        <img src={logoTitle} alt="KUrier Free Logo" className="w-[220px] mb-2" />
+        <div className="text-[#888888] text-[15px] leading-[28px] font-normal">
+          장애 학생과 서포터즈를 하나로,<br />
+          건국대학교의 배리어프리 솔루션
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ServiceInfoCard;

--- a/src/components/common/ServiceInfoCard.tsx
+++ b/src/components/common/ServiceInfoCard.tsx
@@ -3,10 +3,10 @@ import logoTitle from '../../assets/images/logo-title.svg'
 
 const ServiceInfoCard = () => {
   return (
-    <div className="bg-white rounded-2xl border border-[#D9D9D9] px-8 py-6 flex items-center gap-6 shadow-sm w-[400px] min-w-[320px] max-w-full">
-      <img src={logo} alt="KUrier Free Logo" className="w-28 h-28" />
+    <div className="w-[456px] bg-white rounded-2xl border border-[#D9D9D9] px-8 py-6 flex items-center gap-6 shadow-sm min-w-[456px] max-w-[456px]">
+      <img src={logo} alt="KUrier Free Logo" className="w-25 h-25" />
       <div>
-        <img src={logoTitle} alt="KUrier Free Logo" className="w-[220px] mb-2" />
+        <img src={logoTitle} alt="KUrier Free Logo" className="w-[150px] mb-2" />
         <div className="text-[#888888] text-[15px] leading-[28px] font-normal">
           장애 학생과 서포터즈를 하나로,<br />
           건국대학교의 배리어프리 솔루션

--- a/src/pages/supporter/SupporterMain.tsx
+++ b/src/pages/supporter/SupporterMain.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const SupporterMain: React.FC = () => {
+  return (
+    <div className="min-h-screen bg-white">
+      <h1>SupporterMain</h1>
+    </div>
+  );
+};
+
+export default SupporterMain;

--- a/src/pages/supporter/SupporterMain.tsx
+++ b/src/pages/supporter/SupporterMain.tsx
@@ -1,14 +1,46 @@
 import React from 'react';
 import Header from '../../components/layout/Header';
 import Footer from '../../components/layout/Footer';
+import ProfileCard from '../../components/common/ProfileCard';
+import ServiceInfoCard from '../../components/common/ServiceInfoCard';
+import LearningHelperCard from '../../components/common/LearningHelperCard';
+import EmergencyContactCard from '../../components/common/EmergencyContactCard';
+import CalendarCard from '../../components/common/CalendarCard';
+import BarrierFreeMapCard from '../../components/common/BarrierFreeMapCard';
 
 const SupporterMain: React.FC = () => {
   return (
-    <div className="min-h-screen bg-white">
+    <div className="flex flex-col min-h-screen bg-gray-50">
+      {/* Header */}
       <Header />
-      <div className="max-w-[1200px] mx-auto px-4 mt-16">
-        <h1>SupporterMain</h1>
-      </div>
+
+      {/* Main */}
+      <main className="flex-1 px-6 py-10 mt-16">
+        <div className="max-w-[1200px] mx-auto flex flex-row gap-8 items-stretch">
+          {/* 왼쪽 컬럼: 프로필 + 캘린더 */}
+          <div className="w-[672px] flex flex-col gap-6">
+            <ProfileCard name="정지원" role="서포터즈" label="담당 학우" people={["김건국", "이건국"]} />
+            <div className="w-full">
+              <CalendarCard />
+            </div>
+          </div>
+          {/* 오른쪽 컬럼: 서비스 소개 + 기능 카드 그룹 */}
+          <div className="w-[456px] flex flex-col gap-4">
+            <ServiceInfoCard />
+            <div className="flex gap-4 h-[170px]">
+              <div className="w-[220px] h-full">
+                <LearningHelperCard />
+              </div>
+              <div className="w-[220px] h-full">
+                <EmergencyContactCard />
+              </div>
+            </div>
+            <BarrierFreeMapCard />
+          </div>
+        </div>
+      </main>
+
+      {/* Footer */}
       <Footer />
     </div>
   );

--- a/src/pages/supporter/SupporterMain.tsx
+++ b/src/pages/supporter/SupporterMain.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
+import Header from '../../components/layout/Header';
+import Footer from '../../components/layout/Footer';
 
 const SupporterMain: React.FC = () => {
   return (
     <div className="min-h-screen bg-white">
-      <h1>SupporterMain</h1>
+      <Header />
+      <div className="max-w-[1200px] mx-auto px-4 mt-16">
+        <h1>SupporterMain</h1>
+      </div>
+      <Footer />
     </div>
   );
 };

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -8,6 +8,7 @@ import AdminMain from "../pages/admin/AdminMain";
 import SupporterMatchingPage from "../pages/admin/matching/SupporterMatchingPage";
 import AdminApplicantMain from "../pages/admin/applicant/AdminApplicantMain";
 import AdminApplicantEdit from "../pages/admin/applicant/AdminApplicantEdit";
+import SupporterMain from "../pages/supporter/SupporterMain";
 
 const AppRoutes = () => {
   return (
@@ -20,6 +21,9 @@ const AppRoutes = () => {
       <Route path="/admin/applicant" element={<AdminApplicantMain />} />
       <Route path="/admin/applicant/list" element={<AdminApplicantEdit />} />
       <Route path="/admin/matching" element={<SupporterMatchingPage />} />
+
+      {/* 서포터즈 페이지 */}
+      <Route path="/supporters" element={<SupporterMain />} />
 
       {/* 회원가입 중첩 라우팅 */}
       <Route path="/signup" element={<Signup />}>


### PR DESCRIPTION
### 🥕 ISSUE

Closes [#16](https://github.com/KUrierFree/kurierfree-client/issues/16)

---

### ✅ Key Changes
- SupporterMain(서포터즈 랜딩) 페이지 UI 전체 구조 및 디자인 구현
- ProfileCard, ServiceInfoCard, LearningHelperCard, EmergencyContactCard, BarrierFreeMapCard 등 주요 컴포넌트 추가 및 적용
- heroicons/react 라이브러리 도입 및 아이콘 적용

---

### 📢 To Reviewers
- heroicons/react 라이브러리 추가했습니다. pull 받을 때 install 부탁드립니다!
- 시간표는 추후 컴포넌트가 완성되면 추가할 예정입니다!

---

### 📸 ScreenShot
<img width="1311" alt="image" src="https://github.com/user-attachments/assets/ead61b63-52dd-44c1-8114-4d92a233444b" />