### PR TITLE
Design/#20/supporter-apply-page-publishing

### DIFF
--- a/src/pages/supporter/SupporterApplyPage.tsx
+++ b/src/pages/supporter/SupporterApplyPage.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import Header from '../../components/layout/Header';
+import { useSignupStore } from '../../hooks/useStore';
+import { SignupFormData } from '../../types/user';
+import Footer from '../../components/layout/Footer';
+
+const SupporterApplyPage: React.FC = () => {
+  // 더미 데이터
+  const dummyUserData: SignupFormData = {
+    studentId: '20240001',
+    password: '',
+    passwordConfirm: '',
+    name: '홍길동',
+    department: '컴퓨터공학부',
+    grade: '1학년 1학기',
+    gender: '남성',
+    userType: 'supporter'
+  };
+
+  // 실제로는 API나 상태 관리에서 가져와야 함
+  const { formData } = useSignupStore();
+  const userData = formData.studentId ? formData : dummyUserData;
+
+  return (
+    <div className="min-h-screen flex flex-col bg-white">
+      <Header />
+      <main className="flex-1 flex flex-col items-center pt-32 pb-16 px-4">
+        <div className="w-full max-w-2xl bg-white rounded-xl shadow p-8 border">
+          {/* 제목 */}
+          <h1 className="text-2xl font-bold text-center mb-5 tracking-widest">장애학생 서포터즈 지원서</h1>
+          {/* 기본 정보 표시 (표 스타일) */}
+          <table className="w-full border text-sm mb-6">
+            <tbody>
+              <tr>
+                <td className="border px-2 py-1 bg-gray-100 w-24">소속</td>
+                <td className="border px-2 py-1 bg-gray-50 text-gray-500 italic cursor-not-allowed" colSpan={3}>{userData.department}</td>
+              </tr>
+              <tr>
+                <td className="border px-2 py-1 bg-gray-100">학번</td>
+                <td className="border px-2 py-1 bg-gray-50 text-gray-500 italic cursor-not-allowed">{userData.studentId}</td>
+                <td className="border px-2 py-1 bg-gray-100">학년</td>
+                <td className="border px-2 py-1 bg-gray-50 text-gray-500 italic cursor-not-allowed">{userData.grade}</td>
+              </tr>
+              <tr>
+                <td className="border px-2 py-1 bg-gray-100">성명</td>
+                <td className="border px-2 py-1 bg-gray-50 text-gray-500 italic cursor-not-allowed">{userData.name}</td>
+                <td className="border px-2 py-1 bg-gray-100">성별</td>
+                <td className="border px-2 py-1 bg-gray-50 text-gray-500 italic cursor-not-allowed">{userData.gender}</td>
+              </tr>
+              <tr>
+                <td className="border px-2 py-1 bg-gray-100">생년월일</td>
+                <td className="border px-2 py-1"><input className="w-full" /></td>
+                <td className="border px-2 py-1 bg-gray-100">서포터즈 활동경험</td>
+                <td className="border px-2 py-1" colSpan={3}>
+                  <label className="mr-4"><input type="radio" name="exp" className="mr-1" />유</label>
+                  <label><input type="radio" name="exp" className="mr-1" />무</label>
+                </td>
+              </tr>
+              <tr>
+                <td className="border px-2 py-1 bg-gray-100">E-mail</td>
+                <td className="border px-2 py-1"><input className="w-full" /></td>
+                <td className="border px-2 py-1 bg-gray-100">휴대폰</td>
+                <td className="border px-2 py-1"><input className="w-full" /></td>
+              </tr>
+              <tr>
+                <td className="border px-2 py-1 bg-gray-100">활동 유형</td>
+                <td className="border px-2 py-1" colSpan={5}>
+                  <label className="mr-4"><input type="radio" name="activity" className="mr-1" />국가근로</label>
+                  <label><input type="radio" name="activity" className="mr-1" />사회봉사</label>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          {/* 봉사활동 경력 */}
+          <div className="mb-6">
+            <div className="bg-gray-100 border border-t-0 border-x-0 px-2 py-1 font-semibold">봉사활동 경력</div>
+            <textarea className="w-full border rounded p-2 mt-1 min-h-[80px]" placeholder="봉사활동 경력을 입력하세요" />
+          </div>
+          {/* 희망 활동 및 시간 */}
+          <div className="mb-6">
+            <div className="bg-gray-100 border border-t-0 border-x-0 px-2 py-1 font-semibold">희망 활동 및 활동 가능 시간</div>
+            <table className="w-full border text-sm mt-1">
+              <thead>
+                <tr>
+                  <th className="border px-2 py-1 bg-gray-50">번호</th>
+                  <th className="border px-2 py-1 bg-gray-50">희망 활동</th>
+                  <th className="border px-2 py-1 bg-gray-50">활동 가능 시간</th>
+                </tr>
+              </thead>
+              <tbody>
+                {[1,2,3,4,5].map((n) => (
+                  <tr key={n}>
+                    <td className="border px-2 py-1 text-center">{n}순위</td>
+                    <td className="border px-2 py-1"><input className="w-full" placeholder="예) 수업 지원" /></td>
+                    <td className="border px-2 py-1"><input className="w-full" placeholder="예) 월 9-12시, 화 1-5시 30분" /></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <div className="text-xs text-gray-500 mt-1">* 지정 도우미 활동시 해당 사항 기입</div>
+          </div>
+          {/* 동의 문구 */}
+          <div className="text-xs text-gray-600 mb-6 leading-relaxed">
+            상기 본인은 성실하고 책임감 있게 장애학생 도우미 활동에 임할 것을 서약하며, 개인의 신상 정보를 관리기관의 요구에 따라 성실히 제공하고 정부 정책사업 관련 목적으로 정보를 공개(도우미 활동 장학금 지급 및 각종 통계 및 설문조사에 한함)하는데 동의합니다.
+          </div>
+          {/* 신청자/날짜 */}
+          <div className="flex justify-end items-center gap-4 mt-4">
+            <div className="flex items-center gap-1">
+              <span>신청자 :</span>
+              <input className="border-b border-gray-400 w-24 text-center" placeholder="이름" />
+              <span>(인)</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <input className="border-b border-gray-400 w-10 text-center" />
+              <span>년</span>
+              <input className="border-b border-gray-400 w-6 text-center" />
+              <span>월</span>
+              <input className="border-b border-gray-400 w-6 text-center" />
+              <span>일</span>
+            </div>
+          </div>
+          {/* 제출 버튼 */}
+          <div className="flex justify-end mt-8">
+            <button
+              type="submit"
+              className="bg-green-600 hover:bg-green-700 text-white font-semibold px-8 py-2 rounded transition"
+            >
+              제출하기
+            </button>
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default SupporterApplyPage;

--- a/src/pages/supporter/SupporterApplyPage.tsx
+++ b/src/pages/supporter/SupporterApplyPage.tsx
@@ -22,7 +22,7 @@ const SupporterApplyPage: React.FC = () => {
   const userData = formData.studentId ? formData : dummyUserData;
 
   return (
-    <div className="min-h-screen flex flex-col bg-white">
+    <div className="min-h-screen flex flex-col bg-gray-50">
       <Header />
       <main className="flex-1 flex flex-col items-center pt-32 pb-16 px-4">
         <div className="w-full max-w-2xl bg-white rounded-xl shadow p-8 border">
@@ -32,38 +32,38 @@ const SupporterApplyPage: React.FC = () => {
           <table className="w-full border text-sm mb-6">
             <tbody>
               <tr>
-                <td className="border px-2 py-1 bg-gray-100 w-24">소속</td>
+                <th className="border px-2 py-1 bg-gray-100 w-24">소속</th>
                 <td className="border px-2 py-1 bg-gray-50 text-gray-500 italic cursor-not-allowed" colSpan={3}>{userData.department}</td>
               </tr>
               <tr>
-                <td className="border px-2 py-1 bg-gray-100">학번</td>
+                <th className="border px-2 py-1 bg-gray-100">학번</th>
                 <td className="border px-2 py-1 bg-gray-50 text-gray-500 italic cursor-not-allowed">{userData.studentId}</td>
-                <td className="border px-2 py-1 bg-gray-100">학년</td>
+                <th className="border px-2 py-1 bg-gray-100">학년</th>
                 <td className="border px-2 py-1 bg-gray-50 text-gray-500 italic cursor-not-allowed">{userData.grade}</td>
               </tr>
               <tr>
-                <td className="border px-2 py-1 bg-gray-100">성명</td>
+                <th className="border px-2 py-1 bg-gray-100">성명</th>
                 <td className="border px-2 py-1 bg-gray-50 text-gray-500 italic cursor-not-allowed">{userData.name}</td>
-                <td className="border px-2 py-1 bg-gray-100">성별</td>
+                <th className="border px-2 py-1 bg-gray-100">성별</th>
                 <td className="border px-2 py-1 bg-gray-50 text-gray-500 italic cursor-not-allowed">{userData.gender}</td>
               </tr>
               <tr>
-                <td className="border px-2 py-1 bg-gray-100">생년월일</td>
+                <th className="border px-2 py-1 bg-gray-100">생년월일</th>
                 <td className="border px-2 py-1"><input className="w-full" /></td>
-                <td className="border px-2 py-1 bg-gray-100">서포터즈 활동경험</td>
+                <th className="border px-2 py-1 bg-gray-100">서포터즈 활동경험</th>
                 <td className="border px-2 py-1" colSpan={3}>
                   <label className="mr-4"><input type="radio" name="exp" className="mr-1" />유</label>
                   <label><input type="radio" name="exp" className="mr-1" />무</label>
                 </td>
               </tr>
               <tr>
-                <td className="border px-2 py-1 bg-gray-100">E-mail</td>
+                <th className="border px-2 py-1 bg-gray-100">E-mail</th>
                 <td className="border px-2 py-1"><input className="w-full" /></td>
-                <td className="border px-2 py-1 bg-gray-100">휴대폰</td>
+                <th className="border px-2 py-1 bg-gray-100">휴대폰</th>
                 <td className="border px-2 py-1"><input className="w-full" /></td>
               </tr>
               <tr>
-                <td className="border px-2 py-1 bg-gray-100">활동 유형</td>
+                <th className="border px-2 py-1 bg-gray-100">활동 유형</th>
                 <td className="border px-2 py-1" colSpan={5}>
                   <label className="mr-4"><input type="radio" name="activity" className="mr-1" />국가근로</label>
                   <label><input type="radio" name="activity" className="mr-1" />사회봉사</label>

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -9,6 +9,7 @@ import SupporterMatchingPage from "../pages/admin/matching/SupporterMatchingPage
 import AdminApplicantMain from "../pages/admin/applicant/AdminApplicantMain";
 import AdminApplicantEdit from "../pages/admin/applicant/AdminApplicantEdit";
 import SupporterMain from "../pages/supporter/SupporterMain";
+import SupporterApplyPage from "../pages/supporter/SupporterApplyPage";
 
 const AppRoutes = () => {
   return (
@@ -24,6 +25,7 @@ const AppRoutes = () => {
 
       {/* 서포터즈 페이지 */}
       <Route path="/supporters" element={<SupporterMain />} />
+      <Route path="/supporters/apply" element={<SupporterApplyPage />} />
 
       {/* 회원가입 중첩 라우팅 */}
       <Route path="/signup" element={<Signup />}>


### PR DESCRIPTION
### 🥕 ISSUE

Closes [#20](https://github.com/KUrierFree/kurierfree-client/issues/20)

---

### ✅ Key Changes
- 서포터즈의 지원서 페이지를 만들었습니다.
- 회원가입 시 입력한 정보는 수정 불가능하도록 처리

---

### 📢 To Reviewers
<img width="1707" alt="image" src="https://github.com/user-attachments/assets/6f2f703a-6dad-422b-8931-b00091effb8b" />
<img width="1699" alt="image" src="https://github.com/user-attachments/assets/08ad1e25-4b49-41aa-8a66-9f5d6c7a3266" />

- 헤더 색으로 뭐가 나을까요?
- 회원가입 때 받은 데이터들은 이태리체 + 배경 회색 + cursor-not-allowed로 했는데 더 좋은 방법이 있을까요?
- 회원가입 때 학과만 받는데 실제 지원서보면 단과대도 입력받더라고요 일단은 학과만 보이게 했는데, 단과대는 어떻게 하는 게 좋을까요? 생각해본 방법은
  - 1. 단과대 그냥 안 적는다
  - 2. 단과대 회원가입때 입력받도록 수정..은 좀 어려울 것 같고
  - 3. 단과대만 지원서에서 추가로 입력받는다
  - 4. 학과를 토대로 직접 프로그램 내부에서 단과대 정보 매칭
- 서명은 어떻게 받아야 할까요...
---

### 📸 ScreenShot
